### PR TITLE
Recreate db option

### DIFF
--- a/Database/CreatorDb.php
+++ b/Database/CreatorDb.php
@@ -26,18 +26,23 @@ class CreatorDb
      */
     public function create(OutputInterface $output = null)
     {
-        $bufferedOutput = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
-        $error          = false;
+        $error     = false;
+        $outputTmp = null;
+
+        // SF 2.3 does not have BufferedOutput
+        if (class_exists('Symfony\Component\Console\Output\BufferedOutput')) {
+            $outputTmp = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        }
 
         try {
-            $this->executor->execute('doctrine:database:drop --force', $bufferedOutput);
+            $this->executor->execute('doctrine:database:drop --force', $outputTmp);
         } catch (\RuntimeException $e) {
             // catches an error if database does not exist
             $error = true;
         }
 
-        if (! $error) {
-            $output->write($bufferedOutput->fetch());
+        if (! $error && $outputTmp) {
+            $output->write($outputTmp->fetch());
         }
 
         $this->executor->execute('doctrine:database:create', $output);

--- a/Database/CreatorDb.php
+++ b/Database/CreatorDb.php
@@ -3,6 +3,7 @@
 namespace Velikonja\LabbyBundle\Database;
 
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Velikonja\LabbyBundle\Executor\SymfonyCommandExecutor;
 
@@ -27,7 +28,7 @@ class CreatorDb
     public function create(OutputInterface $output = null)
     {
         $error     = false;
-        $outputTmp = null;
+        $outputTmp = new NullOutput();
 
         // SF 2.3 does not have BufferedOutput
         if (class_exists('Symfony\Component\Console\Output\BufferedOutput')) {
@@ -41,7 +42,7 @@ class CreatorDb
             $error = true;
         }
 
-        if (! $error && $outputTmp) {
+        if (! $error && method_exists($outputTmp, 'fetch')) {
             $output->write($outputTmp->fetch());
         }
 

--- a/Database/CreatorDb.php
+++ b/Database/CreatorDb.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Velikonja\LabbyBundle\Database;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Velikonja\LabbyBundle\Executor\SymfonyCommandExecutor;
+
+class CreatorDb
+{
+    /**
+     * @var SymfonyCommandExecutor
+     */
+    private $executor;
+
+    /**
+     * @param SymfonyCommandExecutor $executor
+     */
+    public function __construct(SymfonyCommandExecutor $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function create(OutputInterface $output = null)
+    {
+        $this->executor->execute('doctrine:database:drop --force', $output);
+        $this->executor->execute('doctrine:database:create', $output);
+    }
+}

--- a/Database/CreatorDb.php
+++ b/Database/CreatorDb.php
@@ -2,6 +2,7 @@
 
 namespace Velikonja\LabbyBundle\Database;
 
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Velikonja\LabbyBundle\Executor\SymfonyCommandExecutor;
 
@@ -25,7 +26,20 @@ class CreatorDb
      */
     public function create(OutputInterface $output = null)
     {
-        $this->executor->execute('doctrine:database:drop --force', $output);
+        $bufferedOutput = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $error          = false;
+
+        try {
+            $this->executor->execute('doctrine:database:drop --force', $bufferedOutput);
+        } catch (\RuntimeException $e) {
+            // catches an error if database does not exist
+            $error = true;
+        }
+
+        if (! $error) {
+            $output->write($bufferedOutput->fetch());
+        }
+
         $this->executor->execute('doctrine:database:create', $output);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,8 +37,9 @@ class Configuration implements ConfigurationInterface
                     $this->addSyncFsNode()
                 )
                 ->arrayNode('db')
-                    // copy from doctrine dbal config
                     ->children()
+                        ->booleanNode('recreate')->defaultValue(true)->end()
+                        // copy from doctrine dbal config
                         ->scalarNode('driver')->end()
                         ->scalarNode('dbname')->end()
                         ->scalarNode('host')->defaultValue('localhost')->end()

--- a/DependencyInjection/VelikonjaLabbyExtension.php
+++ b/DependencyInjection/VelikonjaLabbyExtension.php
@@ -33,6 +33,10 @@ class VelikonjaLabbyExtension extends Extension implements PrependExtensionInter
         $container->setParameter('velikonja_labby.config.remote', $config['remote']);
         $container->setParameter('velikonja_labby.config.roles', $config['roles']);
         $container->setParameter('velikonja_labby.config.process_timeout', $config['process_timeout']);
+
+        if (! $config['db']['recreate']) {
+            $container->removeDefinition('velikonja_labby.event.listener.recreate_database');
+        }
     }
 
     /**

--- a/Event/Listener/RecreateDatabaseListener.php
+++ b/Event/Listener/RecreateDatabaseListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Velikonja\LabbyBundle\Event\Listener;
+
+use Velikonja\LabbyBundle\Database\CreatorDB;
+use Velikonja\LabbyBundle\Event\SyncEvent;
+
+class RecreateDatabaseListener
+{
+    /**
+     * @var CreatorDB
+     */
+    private $creator;
+
+    /**
+     * @param CreatorDB $creator
+     */
+    public function __construct(CreatorDB $creator)
+    {
+        $this->creator = $creator;
+    }
+
+    /**
+     * Changes password for all users.
+     *
+     * @param SyncEvent $event
+     */
+    public function onPreSyncDb(SyncEvent $event)
+    {
+        $this->creator->create($event->getOutput());
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LabbyBundle is Symfony2 bundle for retrieving database and assets from one stage
 **Add LabbyBundle by running this command**
 
 ```bash
-$ composer.phar require velikonja/labby-bundle "dev-master"
+$ composer.phar require velikonja/labby-bundle "@stable"
 ```
 
 **Enable the bundle in AppKernel**
@@ -41,10 +41,12 @@ public function registerBundles()
 velikonja_labby:
 #  process_timeout: 300    # Timeout for each external process run (import, dump, ssh, scp, ...).
 #  roles: [ remote, local ]
+
   remote:
     hostname: example.com  # Server where the remote is hosted. 
     path:     /var/www/app # Path to application on remote.
-#   env:      prod         # SF env to be run on remote
+#   env:      prod         # SF env to be run on remote (default true)
+
   fs:
 #   timeout: 60            # Number of seconds in which one mapping (not all of them) sync timeouts.
     maps:                  # You can define more different mappings
@@ -54,6 +56,20 @@ velikonja_labby:
       data:
         src: example.com:/var/www/data/
         dst: app/data/
+        
+# db:
+#   recreate:             true # By default this value is true
+
+# Following options are automatically fetched from doctrine.dbal configuration.
+#   driver:               ~
+#   dbname:               ~
+#   host:                 ~
+#   port:                 ~
+#   user:                 ~
+#   password:             ~
+#   charset:              ~
+
+# Run commands (symfony or shell) on certain events.
 #  event_executors:
 #    pre_sync:
 #      - shell: "whoami"
@@ -65,7 +81,7 @@ velikonja_labby:
 
 **Use the command to sync**
 
-Warning: before you can first sync with remote, you have to deploy the code and configuration to remote.
+**Warning**: *Before you can first sync with remote, you have to deploy the code and configuration to remote.*
 
 Sync assets and database:
 ```bash

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,10 +12,12 @@
         <parameter key="velikonja_labby.service.db.syncer.class">Velikonja\LabbyBundle\Database\SyncerDb</parameter>
         <parameter key="velikonja_labby.service.db.dumper.class">Velikonja\LabbyBundle\Database\Mysql\MySqlDumper</parameter>
         <parameter key="velikonja_labby.service.db.importer.class">Velikonja\LabbyBundle\Database\Mysql\MySqlImporter</parameter>
+        <parameter key="velikonja_labby.service.db.creator.class">Velikonja\LabbyBundle\Database\CreatorDb</parameter>
         <parameter key="velikonja_labby.util.zip_archive.class">Velikonja\LabbyBundle\Util\ZipArchive</parameter>
         <parameter key="velikonja_labby.executor.executor_runner.class">Velikonja\LabbyBundle\Executor\ExecutorRunner</parameter>
         <parameter key="velikonja_labby.executor.shell.class">Velikonja\LabbyBundle\Executor\ShellExecutor</parameter>
         <parameter key="velikonja_labby.executor.sf.class">Velikonja\LabbyBundle\Executor\SymfonyCommandExecutor</parameter>
+        <parameter key="velikonja_labby.event.listener.recreate_database.class">Velikonja\LabbyBundle\Event\Listener\RecreateDatabaseListener</parameter>
     </parameters>
 
     <services>
@@ -51,8 +53,17 @@
             <argument>%velikonja_labby.config.db%</argument>
             <argument>%velikonja_labby.config.process_timeout%</argument>
         </service>
+        <service id="velikonja_labby.service.db.creator" class="%velikonja_labby.service.db.creator.class%">
+            <argument type="service" id="velikonja_labby.executor.sf"/>
+        </service>
 
         <service id="velikonja_labby.util.zip_archive" class="%velikonja_labby.util.zip_archive.class%">
+        </service>
+
+        <!-- Listener -->
+        <service id="velikonja_labby.event.listener.recreate_database" class="%velikonja_labby.event.listener.recreate_database.class%">
+            <argument type="service" id="velikonja_labby.service.db.creator"/>
+            <tag name="kernel.event_listener" event="velikonja_labby.pre_sync.db" method="onPreSyncDb"/>
         </service>
 
         <!-- Executors -->

--- a/Test/Command/CommandTestCase.php
+++ b/Test/Command/CommandTestCase.php
@@ -57,7 +57,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Drops the test database.
      */
-    private function dropTestDB()
+    protected function dropTestDB()
     {
         $exitCode = $this->tester->run(array(
             'command' => 'doctrine:database:drop',
@@ -75,7 +75,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Create test database.
      */
-    private function createTestDB()
+    protected function createTestDB()
     {
         $exitCode = $this->tester->run(array(
             'command' => 'doctrine:database:create'
@@ -91,7 +91,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates temporary folder.
      */
-    private function createTempDir()
+    protected function createTempDir()
     {
         $this->fs->remove($this->tmpDir);
         $this->fs->mkdir(
@@ -104,7 +104,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Remove temporary folder.
      */
-    private function removeTempDir()
+    protected function removeTempDir()
     {
         $this->fs->remove($this->tmpDir);
     }

--- a/Test/Command/SyncDbCommandTest.php
+++ b/Test/Command/SyncDbCommandTest.php
@@ -31,4 +31,13 @@ class SyncDbCommandTest extends CommandTestCase
             'Wrong output of sync:db command detected.'
         );
     }
+
+    /**
+     * Test first drops test database and then runs basic execute to check if db_recreate works.
+     */
+    public function testExecuteWithoutExistingDatabase()
+    {
+        $this->dropTestDB();
+        $this->testExecute();
+    }
 }

--- a/Test/DependencyInjection/ConfigurationTest.php
+++ b/Test/DependencyInjection/ConfigurationTest.php
@@ -71,13 +71,32 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     public function getConfigurationsPaths($type)
     {
-        $files = glob(__DIR__ . sprintf('/../fixtures/configs/%s/*.yml', $type));
-        $args  = array();
+        $files = glob(
+            $this->getConfigsDir() . sprintf('/%s/*.yml', $type)
+        );
+        $args = array();
 
         foreach ($files as $file) {
             $args[] = array($file);
         }
 
         return $args;
+    }
+
+    /**
+     * @return string
+     *
+     */
+    private function getConfigsDir()
+    {
+        $path = realpath(
+            __DIR__ . sprintf('/../fixtures/configs')
+        );
+
+        if (! $path) {
+            throw new \LogicException('Config dir does not exists.');
+        }
+
+        return $path;
     }
 }

--- a/Test/app/config.yml
+++ b/Test/app/config.yml
@@ -6,12 +6,14 @@ framework:
   test:   ~
 
 velikonja_labby:
-  process_timeout: 30
-  roles:           [ remote, local ]
+  process_timeout:    30
+  roles:             [ remote, local ]
   remote:
     hostname: localhost
     path:     %kernel.root_dir%/..
     env:      test
+  db:
+    recreate: true
   fs:
     timeout: 30
     maps:


### PR DESCRIPTION
Bundle can be configured with with `recreate` option to drop database before importing new one. By default this option is **enabled**.

``` yml
velikonja_labby:
  db:
    recreate: true
```

Fixes #8.
