### PR TITLE
Added a list of accepted DBAL config keys

### DIFF
--- a/DependencyInjection/VelikonjaLabbyExtension.php
+++ b/DependencyInjection/VelikonjaLabbyExtension.php
@@ -48,6 +48,16 @@ class VelikonjaLabbyExtension extends Extension implements PrependExtensionInter
     {
         $bundles = $container->getParameter('kernel.bundles');
 
+        $allowedKeys = array(
+            'driver',
+            'dbname',
+            'host',
+            'port',
+            'user',
+            'password',
+            'charset',
+        );
+
         if (isset($bundles['DoctrineBundle'])) {
             $doctrineConfig = $container->getExtensionConfig('doctrine');
 
@@ -55,7 +65,8 @@ class VelikonjaLabbyExtension extends Extension implements PrependExtensionInter
             $length = count($doctrineConfig);
             for ($i = 0; $i < $length; $i++) {
                 if (isset($doctrineConfig[$i]['dbal'])) {
-                    $container->prependExtensionConfig('velikonja_labby', array('db' => $doctrineConfig[$i]['dbal']));
+                    $output = array_intersect_key($doctrineConfig[$i]['dbal'], array_flip($allowedKeys));
+                    $container->prependExtensionConfig('velikonja_labby', array('db' => $output));
                     break;
                 }
             }


### PR DESCRIPTION
I made a list of all DBAL config keys that are relevant to this bundle and filtered out all others.

I had a problem, because the configuration for LabbyBundle could not be created if I used additional configuration for the DBAL, like for instance `server_version` or `types`. I got an error `Unrecognized options "server_version, types" under "velikonja_labby.db"`
