### PR TITLE
Do not hardcode the path to the mysql binary

### DIFF
--- a/Database/Mysql/MySqlImporter.php
+++ b/Database/Mysql/MySqlImporter.php
@@ -32,7 +32,7 @@ class MySqlImporter implements ImporterInterface
         ProcessBuilder $processBuilder = null
     ) {
         if (! $executable) {
-            $executable = '/usr/bin/mysql';
+            $executable = 'mysql';
         }
 
         $this->executable = $executable;


### PR DESCRIPTION
In certain environments the mysql binary might not be located at the hardcoded path.
